### PR TITLE
Fix timer callback typo

### DIFF
--- a/src/ClusterSetter.cpp
+++ b/src/ClusterSetter.cpp
@@ -58,7 +58,7 @@ void ClusterSetter::set_timer(dpp::cluster &bot, DBAdapter &db_adapter) {
               }
             });
       },
-      300, [](dpp::timer timer) { spdlog::debug("timer stoped"); });
+      300, [](dpp::timer timer) { spdlog::debug("timer stopped"); });
 }
 
 void ClusterSetter::add_white_list(DBAdapter &db_adapter,


### PR DESCRIPTION
## Summary
- fix debug message to show `timer stopped` instead of `timer stoped`

## Testing
- `cmake -S . -B build` *(fails: missing SQLiteCpp)*

------
https://chatgpt.com/codex/tasks/task_e_684195b9b2f0832e973b9ee72c4179ef