### PR TITLE
Fix role column index in DBAdapter

### DIFF
--- a/src/DBAdapter.cpp
+++ b/src/DBAdapter.cpp
@@ -314,7 +314,7 @@ void DBAdapter::cash_roles() {
       const uint64_t role_id = std::stoull(query.getColumn(1));
       const int64_t points_threshold = std::stoi(query.getColumn(2));
       const int8_t is_best_in_text = query.getColumn(3);
-      const int8_t is_best_in_voice = query.getColumn(3);
+      const int8_t is_best_in_voice = query.getColumn(4);
 
       roles_[guild_id].push_back({role_id, points_threshold,
                                   static_cast<bool>(is_best_in_text),


### PR DESCRIPTION
## Summary
- fix column index when loading guild roles

## Testing
- `cmake ..` *(fails: FindSQLiteCpp.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196688604832e84df8e4bbe75e5c5