### PR TITLE
Fix: use artifact action v4

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,7 +54,7 @@ jobs:
         cd ..
       
     - name: Export
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: export-binaries
         path: build


### PR DESCRIPTION
## Summary
- update `.github/workflows/cmake.yml` to use `actions/upload-artifact@v4`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a9146182c832ebb8df711272471ed